### PR TITLE
Bug 584 - Allow sftp as copy and commit-archive location destination.

### DIFF
--- a/scripts/vyatta-commit-push.pl
+++ b/scripts/vyatta-commit-push.pl
@@ -85,7 +85,7 @@ foreach my $uri (@uris) {
     print "  $remote ";
 
     my $rc = 0;
-    if ($scheme eq 'scp' ){
+    if ($scheme =~ /^(scp|sftp)$/ ){
         $cmd = "curl -s -S -T $tmp_push_file $uri/$save_file";
         $rc = system($cmd);
         if( $rc >> 8 == 51 ){

--- a/scripts/vyatta-config-mgmt.pl
+++ b/scripts/vyatta-config-mgmt.pl
@@ -175,6 +175,7 @@ if ($action eq 'valid-uri') {
     if ($scheme eq 'tftp') {
     } elsif ($scheme eq 'ftp') {
     } elsif ($scheme eq 'scp') {
+    } elsif ($scheme eq 'sftp') {
     } else {
         print "Unsupported URI scheme\n";
         exit 1;

--- a/templates-cfg/system/config-management/commit-archive/location/node.def
+++ b/templates-cfg/system/config-management/commit-archive/location/node.def
@@ -9,5 +9,6 @@ syntax:expression: exec "/opt/vyatta/sbin/vyatta-config-mgmt.pl \
 val_help: <uri> ; Uniform Resource Identifier
 comp_help: 
   "scp://<user>:<passwd>@<host>/<dir>"
+  "sftp://<user>:<passwd>@<host>/<dir>"
   "ftp://<user>:<passwd>@<host>/<dir>"
   "tftp://<host>/<dir>"


### PR DESCRIPTION
Allow sftp as copy and commit-archive location destination

This patch adds support for allowing sftp scheme as destination for commit-archive location.
Needs https://github.com/vyos/vyatta-cfg/pull/5 for underlying functionality.
