### PR TITLE
T3285, T661: Schedule commit-confirm reboots through systemd

### DIFF
--- a/scripts/commit-confirm-notify.py
+++ b/scripts/commit-confirm-notify.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import os
+import sys
+import time
+
+# Minutes before reboot to trigger notification.
+intervals = [1, 5, 15, 60]
+
+def notify(interval):
+    s = "" if interval == 1 else "s"
+    time.sleep((minutes - interval) * 60)
+    message = ('"[commit-confirm] System is going to reboot in '
+               f'{interval} minute{s} to rollback the last commit.\n'
+               'Confirm your changes to cancel the reboot."')
+    os.system("wall -n " + message)
+
+if __name__ == "__main__":
+    # Must be run as root to call wall(1) without a banner.
+    if len(sys.argv) != 2 or os.getuid() != 0:
+        exit(1)
+    minutes = int(sys.argv[1])
+    # Drop the argument from the list so that the notification
+    # doesn't kick in immediately.
+    if minutes in intervals:
+        intervals.remove(minutes)
+    for interval in sorted(intervals, reverse=True):
+        if minutes >= interval:
+            notify(interval)
+            minutes -= (minutes - interval)
+    exit(0)


### PR DESCRIPTION
Per [T3285](https://phabricator.vyos.net/T3285) and [T661](https://phabricator.vyos.net/T661).

Previously, `commit-confirm` created an `at` job to call the mgmt script for rollback.  
Now `commit-confirm` starts a oneshot systemd timer (stopped on `confirm`) that schedules a transient service for the rollback, then forks an ad hoc notification daemon (which is killed on `confirm`) that sends a `wall(1)` message to notify the users of an impending reboot every so often (see `intervals[]`).

Plus minor cosmetic changes for internal consistency and clearer message strings.

Tested on 1.4-rolling-202101240218.