### PR TITLE
remote: T4029: Fix source address args for upload

### DIFF
--- a/scripts/vyatta-commit-push.pl
+++ b/scripts/vyatta-commit-push.pl
@@ -97,7 +97,12 @@ foreach my $uri (@uris) {
     $remote .= "$path" if defined $path;
     print "  $remote ";
 
-    system("python3 -c 'from vyos.remote import upload; upload(\"$tmp_push_file\", \"$uri/$save_file\", source_host=$source_address)'");
+    # Don't set var 'source_host' if 'source-address' not in configuration
+    if ($source_address eq "None") {
+        system("python3 -c 'from vyos.remote import upload; upload(\"$tmp_push_file\", \"$uri/$save_file\")'");
+    } else {
+        system("python3 -c 'from vyos.remote import upload; upload(\"$tmp_push_file\", \"$uri/$save_file\", source_host=$source_address)'");
+    }
 }
 
 move($tmp_push_file, $last_push_file);


### PR DESCRIPTION
https://phabricator.vyos.net/T4029

Don't set var 'source_host' if 'source-address' not in configuration

Test without source-address:
```
set system config-management commit-archive location 'sftp://foo:foo@192.168.122.14/'

vyos@r11-roll# set interfaces ethernet eth0 description foo
[edit]
vyos@r11-roll# commit
Archiving config...
  sftp://192.168.122.14/ Host '192.168.122.14' not found in known hosts.
Fingerprint: e6b086a4df5e46755bda0c3877f255bf
Do you wish to continue? [y/N] y
[edit]

```
Test with source-address:
```
set system config-management commit-archive location 'sftp://foo:foo@192.168.122.14/'
set system config-management commit-archive source-address 192.168.122.11

vyos@r11-roll# set interfaces ethernet eth0 description foo-foo
[edit]
vyos@r11-roll# commit
Using source address 192.168.122.11
Archiving config...
  sftp://192.168.122.14/ Host '192.168.122.14' not found in known hosts.
Fingerprint: e6b086a4df5e46755bda0c3877f255bf
Do you wish to continue? [y/N] y
[edit]
vyos@r11-roll# 
```
