### PR TITLE
remote: T4101: Initialize source address string as empty string if none provided

### DIFF
--- a/scripts/vyatta-commit-push.pl
+++ b/scripts/vyatta-commit-push.pl
@@ -74,6 +74,9 @@ my $source_address = $config->returnEffectiveValue('source-address');
 if (defined($source_address)) {
     print("Using source address $source_address\n");
 }
+else {
+    $source_address = '';
+}
 # The string needs to be wrapped in quotes, even if it's empty.
 $source_address = '"' . $source_address . '"';
 


### PR DESCRIPTION
(for Equuleus)

https://phabricator.vyos.net/T4101